### PR TITLE
Allow JobStorage to reset the EntityManager

### DIFF
--- a/Doctrine/JobStorage.php
+++ b/Doctrine/JobStorage.php
@@ -214,7 +214,8 @@ class JobStorage
         }
 
         if (!$this->em->isOpen()) {
-            $this->em = $this->doctrine->resetManager();
+            $this->doctrine->resetManager();
+            $this->em = $this->doctrine->getManagerForClass($this->entityClass);
         }
 
         return $this->em;

--- a/Doctrine/JobStorage.php
+++ b/Doctrine/JobStorage.php
@@ -212,10 +212,8 @@ class JobStorage
         if (!$this->em) {
             $this->em = $this->doctrine->getManagerForClass($this->entityClass);
         }
-
         if (!$this->em->isOpen()) {
-            $this->doctrine->resetManager();
-            $this->em = $this->doctrine->getManagerForClass($this->entityClass);
+            $this->em = $this->doctrine->resetManager();
         }
 
         return $this->em;

--- a/Doctrine/JobStorage.php
+++ b/Doctrine/JobStorage.php
@@ -213,6 +213,10 @@ class JobStorage
             $this->em = $this->doctrine->getManagerForClass($this->entityClass);
         }
 
+        if (!$this->em->isOpen()) {
+            $this->em = $this->doctrine->resetManager();
+        }
+
         return $this->em;
     }
 }

--- a/Tests/Doctrine/JobStorageTest.php
+++ b/Tests/Doctrine/JobStorageTest.php
@@ -35,16 +35,61 @@ class JobStorageTest extends \PHPUnit\Framework\TestCase
             ->with('entity-class')
             ->will($this->returnValue($repository))
         ;
+        $em
+            ->expects($this->any())
+            ->method('isOpen')
+            ->will($this->returnValue(true))
+        ;
 
         $doctrine = $this->createDoctrineMock();
         $doctrine
-            ->expects($this->atMost(2))
+            ->expects($this->once())
             ->method('getManagerForClass')
             ->with('entity-class')
             ->will($this->returnValue($em))
         ;
         $doctrine
-            ->expects($this->atMost(1))
+            ->expects($this->never())
+            ->method('resetManager')
+        ;
+
+        $storage = new JobStorage($doctrine, 'entity-class', 'unique_table');
+        $job = $storage->createJob();
+
+        $this->assertInstanceOf(Job::class, $job);
+    }
+
+    public function testShouldResetManagerAndCreateJobObject()
+    {
+        $repository = $this->createRepositoryMock();
+        $repository
+            ->expects($this->once())
+            ->method('getClassName')
+            ->will($this->returnValue(Job::class))
+        ;
+
+        $em = $this->createEntityManagerMock();
+        $em
+            ->expects($this->once())
+            ->method('getRepository')
+            ->with('entity-class')
+            ->will($this->returnValue($repository))
+        ;
+        $em
+            ->expects($this->any())
+            ->method('isOpen')
+            ->will($this->returnValue(false))
+        ;
+
+        $doctrine = $this->createDoctrineMock();
+        $doctrine
+            ->expects($this->once())
+            ->method('getManagerForClass')
+            ->with('entity-class')
+            ->will($this->returnValue($em))
+        ;
+        $doctrine
+            ->expects($this->any())
             ->method('resetManager')
             ->will($this->returnValue($em))
         ;
@@ -71,18 +116,22 @@ class JobStorageTest extends \PHPUnit\Framework\TestCase
             ->with('entity-class')
             ->will($this->returnValue($repository))
         ;
+        $em
+            ->expects($this->any())
+            ->method('isOpen')
+            ->will($this->returnValue(true))
+        ;
 
         $doctrine = $this->createDoctrineMock();
         $doctrine
-            ->expects($this->atMost(2))
+            ->expects($this->once())
             ->method('getManagerForClass')
             ->with('entity-class')
             ->will($this->returnValue($em))
         ;
         $doctrine
-            ->expects($this->atMost(1))
+            ->expects($this->never())
             ->method('resetManager')
-            ->will($this->returnValue($em))
         ;
 
         $storage = new JobStorage($doctrine, 'entity-class', 'unique_table');
@@ -130,18 +179,22 @@ class JobStorageTest extends \PHPUnit\Framework\TestCase
             ->expects($this->never())
             ->method('transactional')
         ;
+        $em
+            ->expects($this->any())
+            ->method('isOpen')
+            ->will($this->returnValue(true))
+        ;
 
         $doctrine = $this->createDoctrineMock();
         $doctrine
-            ->expects($this->atMost(2))
+            ->expects($this->once())
             ->method('getManagerForClass')
             ->with('entity-class')
             ->will($this->returnValue($em))
         ;
         $doctrine
-            ->expects($this->atMost(1))
+            ->expects($this->never())
             ->method('resetManager')
-            ->will($this->returnValue($em))
         ;
 
         $storage = new JobStorage($doctrine, 'entity-class', 'unique_table');
@@ -180,18 +233,22 @@ class JobStorageTest extends \PHPUnit\Framework\TestCase
             ->expects($this->once())
             ->method('transactional')
         ;
+        $em
+            ->expects($this->any())
+            ->method('isOpen')
+            ->will($this->returnValue(true))
+        ;
 
         $doctrine = $this->createDoctrineMock();
         $doctrine
-            ->expects($this->atMost(2))
+            ->expects($this->once())
             ->method('getManagerForClass')
             ->with('entity-class')
             ->will($this->returnValue($em))
         ;
         $doctrine
-            ->expects($this->atMost(1))
+            ->expects($this->never())
             ->method('resetManager')
-            ->will($this->returnValue($em))
         ;
 
         $storage = new JobStorage($doctrine, 'entity-class', 'unique_table');
@@ -239,18 +296,22 @@ class JobStorageTest extends \PHPUnit\Framework\TestCase
             ->method('getConnection')
             ->will($this->returnValue($connection))
         ;
+        $em
+            ->expects($this->any())
+            ->method('isOpen')
+            ->will($this->returnValue(true))
+        ;
 
         $doctrine = $this->createDoctrineMock();
         $doctrine
-            ->expects($this->atMost(2))
+            ->expects($this->once())
             ->method('getManagerForClass')
             ->with('entity-class')
             ->will($this->returnValue($em))
         ;
         $doctrine
-            ->expects($this->atMost(1))
+            ->expects($this->never())
             ->method('resetManager')
-            ->will($this->returnValue($em))
         ;
 
         $storage = new JobStorage($doctrine, 'entity-class', 'unique_table');
@@ -278,18 +339,22 @@ class JobStorageTest extends \PHPUnit\Framework\TestCase
             ->with('entity-class')
             ->will($this->returnValue($repository))
         ;
+        $em
+            ->expects($this->any())
+            ->method('isOpen')
+            ->will($this->returnValue(true))
+        ;
 
         $doctrine = $this->createDoctrineMock();
         $doctrine
-            ->expects($this->atMost(2))
+            ->expects($this->once())
             ->method('getManagerForClass')
             ->with('entity-class')
             ->will($this->returnValue($em))
         ;
         $doctrine
-            ->expects($this->atMost(1))
+            ->expects($this->never())
             ->method('resetManager')
-            ->will($this->returnValue($em))
         ;
 
         $storage = new JobStorage($doctrine, 'entity-class', 'unique_table');
@@ -336,18 +401,22 @@ class JobStorageTest extends \PHPUnit\Framework\TestCase
                 $callback($em);
             }))
         ;
+        $em
+            ->expects($this->any())
+            ->method('isOpen')
+            ->will($this->returnValue(true))
+        ;
 
         $doctrine = $this->createDoctrineMock();
         $doctrine
-            ->expects($this->atMost(2))
+            ->expects($this->once())
             ->method('getManagerForClass')
             ->with('entity-class')
             ->will($this->returnValue($em))
         ;
         $doctrine
-            ->expects($this->atMost(1))
+            ->expects($this->never())
             ->method('resetManager')
-            ->will($this->returnValue($em))
         ;
 
         $storage = new JobStorage($doctrine, 'entity-class', 'unique_table');
@@ -412,18 +481,22 @@ class JobStorageTest extends \PHPUnit\Framework\TestCase
             ->expects($this->once())
             ->method('flush')
         ;
+        $em
+            ->expects($this->any())
+            ->method('isOpen')
+            ->will($this->returnValue(true))
+        ;
 
         $doctrine = $this->createDoctrineMock();
         $doctrine
-            ->expects($this->atMost(2))
+            ->expects($this->once())
             ->method('getManagerForClass')
             ->with('entity-class')
             ->will($this->returnValue($em))
         ;
         $doctrine
-            ->expects($this->atMost(1))
+            ->expects($this->never())
             ->method('resetManager')
-            ->will($this->returnValue($em))
         ;
 
         $storage = new JobStorage($doctrine, 'entity-class', 'unique_table');
@@ -482,18 +555,22 @@ class JobStorageTest extends \PHPUnit\Framework\TestCase
             ->method('getConnection')
             ->will($this->returnValue($connection))
         ;
+        $em
+            ->expects($this->any())
+            ->method('isOpen')
+            ->will($this->returnValue(true))
+        ;
 
         $doctrine = $this->createDoctrineMock();
         $doctrine
-            ->expects($this->atMost(2))
+            ->expects($this->once())
             ->method('getManagerForClass')
             ->with('entity-class')
             ->will($this->returnValue($em))
         ;
         $doctrine
-            ->expects($this->atMost(1))
+            ->expects($this->never())
             ->method('resetManager')
-            ->will($this->returnValue($em))
         ;
 
         $storage = new JobStorage($doctrine, 'entity-class', 'unique_table');

--- a/Tests/Doctrine/JobStorageTest.php
+++ b/Tests/Doctrine/JobStorageTest.php
@@ -38,9 +38,14 @@ class JobStorageTest extends \PHPUnit\Framework\TestCase
 
         $doctrine = $this->createDoctrineMock();
         $doctrine
-            ->expects($this->once())
+            ->expects($this->atMost(2))
             ->method('getManagerForClass')
             ->with('entity-class')
+            ->will($this->returnValue($em))
+        ;
+        $doctrine
+            ->expects($this->atMost(1))
+            ->method('resetManager')
             ->will($this->returnValue($em))
         ;
 
@@ -69,9 +74,14 @@ class JobStorageTest extends \PHPUnit\Framework\TestCase
 
         $doctrine = $this->createDoctrineMock();
         $doctrine
-            ->expects($this->once())
+            ->expects($this->atMost(2))
             ->method('getManagerForClass')
             ->with('entity-class')
+            ->will($this->returnValue($em))
+        ;
+        $doctrine
+            ->expects($this->atMost(1))
+            ->method('resetManager')
             ->will($this->returnValue($em))
         ;
 
@@ -123,9 +133,14 @@ class JobStorageTest extends \PHPUnit\Framework\TestCase
 
         $doctrine = $this->createDoctrineMock();
         $doctrine
-            ->expects($this->once())
+            ->expects($this->atMost(2))
             ->method('getManagerForClass')
             ->with('entity-class')
+            ->will($this->returnValue($em))
+        ;
+        $doctrine
+            ->expects($this->atMost(1))
+            ->method('resetManager')
             ->will($this->returnValue($em))
         ;
 
@@ -168,9 +183,14 @@ class JobStorageTest extends \PHPUnit\Framework\TestCase
 
         $doctrine = $this->createDoctrineMock();
         $doctrine
-            ->expects($this->once())
+            ->expects($this->atMost(2))
             ->method('getManagerForClass')
             ->with('entity-class')
+            ->will($this->returnValue($em))
+        ;
+        $doctrine
+            ->expects($this->atMost(1))
+            ->method('resetManager')
             ->will($this->returnValue($em))
         ;
 
@@ -222,9 +242,14 @@ class JobStorageTest extends \PHPUnit\Framework\TestCase
 
         $doctrine = $this->createDoctrineMock();
         $doctrine
-            ->expects($this->once())
+            ->expects($this->atMost(2))
             ->method('getManagerForClass')
             ->with('entity-class')
+            ->will($this->returnValue($em))
+        ;
+        $doctrine
+            ->expects($this->atMost(1))
+            ->method('resetManager')
             ->will($this->returnValue($em))
         ;
 
@@ -256,9 +281,14 @@ class JobStorageTest extends \PHPUnit\Framework\TestCase
 
         $doctrine = $this->createDoctrineMock();
         $doctrine
-            ->expects($this->once())
+            ->expects($this->atMost(2))
             ->method('getManagerForClass')
             ->with('entity-class')
+            ->will($this->returnValue($em))
+        ;
+        $doctrine
+            ->expects($this->atMost(1))
+            ->method('resetManager')
             ->will($this->returnValue($em))
         ;
 
@@ -309,9 +339,14 @@ class JobStorageTest extends \PHPUnit\Framework\TestCase
 
         $doctrine = $this->createDoctrineMock();
         $doctrine
-            ->expects($this->once())
+            ->expects($this->atMost(2))
             ->method('getManagerForClass')
             ->with('entity-class')
+            ->will($this->returnValue($em))
+        ;
+        $doctrine
+            ->expects($this->atMost(1))
+            ->method('resetManager')
             ->will($this->returnValue($em))
         ;
 
@@ -380,9 +415,14 @@ class JobStorageTest extends \PHPUnit\Framework\TestCase
 
         $doctrine = $this->createDoctrineMock();
         $doctrine
-            ->expects($this->once())
+            ->expects($this->atMost(2))
             ->method('getManagerForClass')
             ->with('entity-class')
+            ->will($this->returnValue($em))
+        ;
+        $doctrine
+            ->expects($this->atMost(1))
+            ->method('resetManager')
             ->will($this->returnValue($em))
         ;
 
@@ -445,9 +485,14 @@ class JobStorageTest extends \PHPUnit\Framework\TestCase
 
         $doctrine = $this->createDoctrineMock();
         $doctrine
-            ->expects($this->once())
+            ->expects($this->atMost(2))
             ->method('getManagerForClass')
             ->with('entity-class')
+            ->will($this->returnValue($em))
+        ;
+        $doctrine
+            ->expects($this->atMost(1))
+            ->method('resetManager')
             ->will($this->returnValue($em))
         ;
 


### PR DESCRIPTION
After a Job triggers a Doctrine exception, and handles it, the EntityManager still remains closed and JobStorage can't persist changes. This fix resets the Manager after such an occurrence.