### PR TITLE
Fix Doctrine cache issue when running multiple enqueue processes

### DIFF
--- a/CalculateRootJobStatusProcessor.php
+++ b/CalculateRootJobStatusProcessor.php
@@ -48,7 +48,6 @@ class CalculateRootJobStatusProcessor implements Processor, CommandSubscriberInt
 
     public function process(Message $message, Context $context)
     {
-        $this->jobStorage->clearJobCache();
         $data = JSON::decode($message->getBody());
 
         if (!isset($data['jobId'])) {

--- a/CalculateRootJobStatusProcessor.php
+++ b/CalculateRootJobStatusProcessor.php
@@ -48,6 +48,7 @@ class CalculateRootJobStatusProcessor implements Processor, CommandSubscriberInt
 
     public function process(Message $message, Context $context)
     {
+    	$this->jobStorage->clearJobCache();
         $data = JSON::decode($message->getBody());
 
         if (!isset($data['jobId'])) {

--- a/CalculateRootJobStatusProcessor.php
+++ b/CalculateRootJobStatusProcessor.php
@@ -48,7 +48,7 @@ class CalculateRootJobStatusProcessor implements Processor, CommandSubscriberInt
 
     public function process(Message $message, Context $context)
     {
-    	$this->jobStorage->clearJobCache();
+        $this->jobStorage->clearJobCache();
         $data = JSON::decode($message->getBody());
 
         if (!isset($data['jobId'])) {

--- a/CalculateRootJobStatusService.php
+++ b/CalculateRootJobStatusService.php
@@ -69,6 +69,7 @@ class CalculateRootJobStatusService
         $success = 0;
 
         foreach ($jobs as $job) {
+            $this->jobStorage->refreshedJobEntity($job);
             switch ($job->getStatus()) {
                 case Job::STATUS_NEW:
                     $new++;

--- a/CalculateRootJobStatusService.php
+++ b/CalculateRootJobStatusService.php
@@ -69,7 +69,7 @@ class CalculateRootJobStatusService
         $success = 0;
 
         foreach ($jobs as $job) {
-            $this->jobStorage->refreshedJobEntity($job);
+            $this->jobStorage->refreshJobEntity($job);
             switch ($job->getStatus()) {
                 case Job::STATUS_NEW:
                     $new++;

--- a/Doctrine/JobStorage.php
+++ b/Doctrine/JobStorage.php
@@ -182,7 +182,7 @@ class JobStorage
     /**
      * @param $job
      */
-    public function refreshedJobEntity($job)
+    public function refreshJobEntity($job)
     {
         $this->getEntityManager()->refresh($job);
     }

--- a/Doctrine/JobStorage.php
+++ b/Doctrine/JobStorage.php
@@ -179,9 +179,12 @@ class JobStorage
         }
     }
 
-    public function clearJobCache()
+    /**
+     * @param $job
+     */
+    public function refreshedJobEntity($job)
     {
-        $this->getEntityManager()->clear($this->entityClass);
+        $this->getEntityManager()->refresh($job);
     }
 
     /**

--- a/Doctrine/JobStorage.php
+++ b/Doctrine/JobStorage.php
@@ -58,13 +58,18 @@ class JobStorage
     {
         $qb = $this->getEntityRepository()->createQueryBuilder('job');
 
-        return $qb
+        $job = $qb
             ->addSelect('rootJob')
             ->leftJoin('job.rootJob', 'rootJob')
             ->where('job = :id')
             ->setParameter('id', $id)
             ->getQuery()->getOneOrNullResult()
         ;
+        if ($job) {
+            $this->refreshJobEntity($job);
+        }
+
+        return $job;
     }
 
     /**

--- a/Doctrine/JobStorage.php
+++ b/Doctrine/JobStorage.php
@@ -180,9 +180,9 @@ class JobStorage
     }
 
     public function clearJobCache()
-	{
-		$this->getEntityManager()->clear($this->entityClass);
-	}
+    {
+        $this->getEntityManager()->clear($this->entityClass);
+    }
 
     /**
      * @return EntityRepository

--- a/Doctrine/JobStorage.php
+++ b/Doctrine/JobStorage.php
@@ -179,6 +179,11 @@ class JobStorage
         }
     }
 
+    public function clearJobCache()
+	{
+		$this->getEntityManager()->clear($this->entityClass);
+	}
+
     /**
      * @return EntityRepository
      */


### PR DESCRIPTION
If multiple enqueue processes are run, then doctrine cache should be cleared before calculating root job status, otherwise all child job statuses are cached in Doctrine's request cache and we won't fetch current status of child jobs therefore root job will have running status for ever

This PR fixes issue: php-enqueue/enqueue-dev#1173